### PR TITLE
Fix broken CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/so.kontext/ads.svg?style=flat&logo=android)](https://search.maven.org/artifact/so.kontext/ads)
 [![Kotlin](https://img.shields.io/badge/Kotlin-1.9.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
 [![Apache 2 License](https://img.shields.io/github/license/kontextso/sdk-kotlin)](https://github.com/kontextso/sdk-kotlin/blob/main/LICENSE)
-[![Check Main](https://github.com/kontextso/sdk-kotlin/actions/workflows/check_main.yml/badge.svg)](https://github.com/kontextso/sdk-kotlin/actions/workflows/check_main.yml)
+[![CI Kotlin SDK](https://github.com/kontextso/sdk-kotlin/actions/workflows/kotlin_sdk_ci.yml/badge.svg)](https://github.com/kontextso/sdk-kotlin/actions/workflows/kotlin_sdk_ci.yml)
 
 # Kontext Kotlin SDK
 


### PR DESCRIPTION
## Summary
- `check_main.yml` no longer exists — replaced by `kotlin_sdk_ci.yml`
- Updates the badge URL to point to the correct workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)