### PR TITLE
Restart OMID session on device rotation (TC-72) [don't merge]

### DIFF
--- a/ads/src/main/kotlin/so/kontext/ads/internal/utils/om/WebViewOmSession.kt
+++ b/ads/src/main/kotlin/so/kontext/ads/internal/utils/om/WebViewOmSession.kt
@@ -82,10 +82,13 @@ internal object WebViewOmSession {
         }
     }
 
+    fun hasSession(webView: WebView): Boolean = sessions.containsKey(webView)
+
     fun finish(webView: WebView) {
+        val session = sessions.remove(webView) ?: return
         activeScope.launch {
             webView.evaluateJavascript("window.postMessage({ type: 'retire-iframe' }, '*');", null)
-            sessions.remove(webView)?.finish()
+            session.finish()
         }
     }
 

--- a/ads/src/main/kotlin/so/kontext/ads/ui/InlineAd.kt
+++ b/ads/src/main/kotlin/so/kontext/ads/ui/InlineAd.kt
@@ -155,12 +155,7 @@ public fun InlineAd(
         }
     }
 
-    val isFirstOrientation = remember(adKey) { mutableStateOf(true) }
     LaunchedEffect(webView, orientation) {
-        if (isFirstOrientation.value) {
-            isFirstOrientation.value = false
-            return@LaunchedEffect
-        }
         if (WebViewOmSession.hasSession(webView)) {
             WebViewOmSession.finish(webView)
             WebViewOmSession.start(webView, config.iFrameUrl, config.bid.omCreativeType)

--- a/ads/src/main/kotlin/so/kontext/ads/ui/InlineAd.kt
+++ b/ads/src/main/kotlin/so/kontext/ads/ui/InlineAd.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
@@ -64,6 +65,7 @@ public fun InlineAd(
     val context = LocalContext.current
     val density = LocalDensity.current
     val imeInsets = WindowInsets.ime
+    val orientation = LocalConfiguration.current.orientation
 
     val adKey = remember(config) { config.messageId }
     var heightCssPx by rememberSaveable("inline_ad_height_$adKey") {
@@ -150,6 +152,18 @@ public fun InlineAd(
 
         onDispose {
             webView.onPause()
+        }
+    }
+
+    val isFirstOrientation = remember(adKey) { mutableStateOf(true) }
+    LaunchedEffect(webView, orientation) {
+        if (isFirstOrientation.value) {
+            isFirstOrientation.value = false
+            return@LaunchedEffect
+        }
+        if (WebViewOmSession.hasSession(webView)) {
+            WebViewOmSession.finish(webView)
+            WebViewOmSession.start(webView, config.iFrameUrl, config.bid.omCreativeType)
         }
     }
 


### PR DESCRIPTION
## Summary

- IAB 1.3 TC-72 requires that rotating the device starts a fresh OMID ad session
- Our `InlineAdWebViewPool` keeps WebViews alive across Activity recreation, so no new `sessionStart` was fired on rotation
- Fix: observe `LocalConfiguration.orientation` in `InlineAd` and restart the OMID session when it changes

## Changes

**`WebViewOmSession.kt`**
- `finish()` now removes the entry from the `sessions` map synchronously before launching the cleanup coroutine, so a back-to-back `start()` call is not blocked by the stale `containsKey` check
- Added `hasSession(webView)` to check whether a session is currently active

**`InlineAd.kt`**
- Added `LocalConfiguration.current.orientation` observation
- `LaunchedEffect(webView, orientation)` skips the first composition, then on each orientation change: finishes the current session and starts a new one (ad content is already loaded in the WebView, so no `AdDone` re-trigger is needed)

## Test plan

- [ ] Load a banner/inline display ad
- [ ] Rotate the device
- [ ] Verify in Charles proxy: a new `sessionStart` fires with a different `adSessionId`, followed by `loaded` and `impression`
- [ ] Verify no duplicate sessions when rotating back
- [ ] Verify no regression when ad has not loaded yet before rotation (session should not start prematurely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)