### PR TITLE
Add Robolectric + test 141 → 186

### DIFF
--- a/ads/build.gradle.kts
+++ b/ads/build.gradle.kts
@@ -48,11 +48,16 @@ android {
     }
     testOptions {
         unitTests.all {
-            it.useJUnitPlatform()
+            it.useJUnitPlatform {
+                // Robolectric is JUnit 4 — junit-vintage lets the JUnit Platform
+                // run both engines side-by-side with JUnit 5.
+                includeEngines("junit-jupiter", "junit-vintage")
+            }
         }
+        // Robolectric needs real Android resources + AndroidManifest.
+        unitTests.isIncludeAndroidResources = true
         // Return default values from stubbed Android framework calls (e.g. Log.e)
-        // instead of throwing "Method not mocked" — lets unit tests exercise
-        // fallback paths that log via android.util.Log.
+        // in tests that run without Robolectric.
         unitTests.isReturnDefaultValues = true
     }
 }
@@ -160,4 +165,9 @@ dependencies {
     testImplementation(libs.ktor.client.mock)
     testImplementation(libs.ktor.client.content.negotiation)
     testImplementation(libs.ktor.serialization.kotlinx.json)
+    // Robolectric runs Android framework classes on the JVM.
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.junit) // Robolectric uses JUnit 4
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:${libs.versions.junit.jupiter.get()}")
 }

--- a/ads/src/test/kotlin/so/kontext/ads/internal/AdsProviderImplTest.kt
+++ b/ads/src/test/kotlin/so/kontext/ads/internal/AdsProviderImplTest.kt
@@ -1,0 +1,288 @@
+package so.kontext.ads.internal
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import so.kontext.ads.domain.AdDisplayPosition
+import so.kontext.ads.domain.AdResult
+import so.kontext.ads.domain.AdsMessage
+import so.kontext.ads.domain.Bid
+import so.kontext.ads.domain.PreloadResult
+import so.kontext.ads.domain.Role
+import so.kontext.ads.internal.data.api.AdsApi
+import so.kontext.ads.internal.data.error.ApiError
+import so.kontext.ads.internal.data.repository.AdsRepository
+import so.kontext.ads.internal.di.AdsModule
+import so.kontext.ads.internal.utils.ApiResponse
+import so.kontext.ads.internal.utils.deviceinfo.AppInfo
+import so.kontext.ads.internal.utils.deviceinfo.AudioInfo
+import so.kontext.ads.internal.utils.deviceinfo.BatteryState
+import so.kontext.ads.internal.utils.deviceinfo.DeviceInfo
+import so.kontext.ads.internal.utils.deviceinfo.DeviceInfoProvider
+import so.kontext.ads.internal.utils.deviceinfo.DeviceType
+import so.kontext.ads.internal.utils.deviceinfo.HardwareInfo
+import so.kontext.ads.internal.utils.deviceinfo.NetworkInfo
+import so.kontext.ads.internal.utils.deviceinfo.OsInfo
+import so.kontext.ads.internal.utils.deviceinfo.PowerInfo
+import so.kontext.ads.internal.utils.deviceinfo.ScreenInfo
+import so.kontext.ads.internal.utils.deviceinfo.ScreenOrientation
+import so.kontext.ads.internal.utils.deviceinfo.SdkInfo
+import java.io.IOException
+
+/**
+ * Exercises the orchestrator's setMessages → preload → AdResult pipeline
+ * via real coroutines (AdsProviderImpl owns its internal scope; we can't
+ * cleanly virtualize time through it). The waits below are realistic
+ * (~2 s end-to-end per case) to cover the 300 ms debounce + 1 s minimum
+ * delay in the source.
+ *
+ * Dependencies injected:
+ * - DeviceInfoProvider is a fake with userAgent=null so the init-block
+ *   AdsModule re-creation path does not fire.
+ * - AdsModule is a mock (we never touch the real Ktor client).
+ * - AdsRepository is a mock so we control the preload response shape.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AdsProviderImplTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private lateinit var repo: AdsRepository
+    private lateinit var deviceInfoProvider: DeviceInfoProvider
+    private lateinit var adsModule: AdsModule
+
+    @Before
+    fun setUp() {
+        repo = mockk()
+        deviceInfoProvider = mockk {
+            every { deviceInfo } returns fakeDeviceInfo()
+        }
+        adsModule = mockk(relaxed = true) {
+            every { adsApi } returns mockk<AdsApi>(relaxed = true)
+        }
+    }
+
+    private fun config(
+        isDisabled: Boolean = false,
+        enabledPlacementCodes: List<String> = listOf("inlineAd"),
+    ) = AdsConfiguration(
+        adServerUrl = "https://ads.test",
+        publisherToken = "pub-tok",
+        userId = "u-1",
+        conversationId = "c-1",
+        enabledPlacementCodes = enabledPlacementCodes,
+        character = null,
+        variantId = null,
+        advertisingId = null,
+        isDisabled = isDisabled,
+        theme = null,
+        regulatory = null,
+        userEmail = null,
+    )
+
+    private fun fakeDeviceInfo(): DeviceInfo = DeviceInfo(
+        osInfo = OsInfo("android", "14", "en-US", "UTC"),
+        hardwareInfo = HardwareInfo("Samsung", "S24", DeviceType.Handset, 0L, false),
+        screenInfo = ScreenInfo(1080, 2400, 3f, ScreenOrientation.Portrait, false),
+        powerInfo = PowerInfo(100, BatteryState.Full, false),
+        audioInfo = AudioInfo(50, false, false, emptyList()),
+        // userAgent null → AdsProviderImpl init-block skips the re-creation branch.
+        networkInfo = NetworkInfo(null, null, null, null),
+        appInfo = AppInfo("com.app", "1.0", null, 0, 0, 0),
+        sdkInfo = SdkInfo("sdk-kotlin", "1.0.0", "android"),
+    )
+
+    private fun provider(
+        config: AdsConfiguration = config(),
+    ): AdsProviderImpl {
+        return AdsProviderImpl(
+            context = context,
+            initialMessages = emptyList(),
+            dispatcher = Dispatchers.IO,
+            adsConfiguration = config,
+            deviceInfoProvider = deviceInfoProvider,
+            adsModule = adsModule,
+            repository = repo,
+        )
+    }
+
+    /**
+     * Subscribes to the flow, fires `block()`, waits up to `timeoutMs` for
+     * `count` events, then returns them. Uses real time because
+     * AdsProviderImpl runs its own coroutine scope on the caller's dispatcher.
+     */
+    private fun <T> Flow<T>.collectN(
+        count: Int,
+        timeoutMs: Long = 3_000,
+        block: suspend () -> Unit,
+    ): List<T> = runBlocking {
+        val events = mutableListOf<T>()
+        val job: Job = CoroutineScope(Dispatchers.IO).launch {
+            take(count).toList(events)
+        }
+        block()
+        withTimeoutOrNull(timeoutMs) { job.join() }
+        events
+    }
+
+    private fun userMsg(id: String) = AdsMessage(id, Role.User, "hi", "2025-01-01T00:00:00Z")
+    private fun assistantMsg(id: String) = AdsMessage(id, Role.Assistant, "hello", "2025-01-01T00:00:01Z")
+
+    // ---- Preload happy path ----
+
+    @Test
+    fun `new user message triggers preload and emits Cleared then Filled`() {
+        val bid = Bid(
+            bidId = "bid-1",
+            code = "inlineAd",
+            adDisplayPosition = AdDisplayPosition.AfterAssistantMessage,
+        )
+        coEvery { repo.preload(any(), any(), any(), any(), any(), any()) } returns ApiResponse.Success(
+            PreloadResult(
+                bids = listOf(bid),
+                sessionId = "s-1",
+                remoteLogLevel = null,
+                preloadTimeout = null,
+                skip = null,
+                skipCode = null,
+            ),
+        )
+
+        val provider = provider()
+        val events = provider.ads.collectN(2, timeoutMs = 5_000) {
+            provider.setMessages(listOf(userMsg("u-1"), assistantMsg("a-1")))
+            // 300 ms debounce + repo.preload (instant mock) + 1 s minimumDelayJob
+            delay(1_600)
+        }
+
+        assertTrue("Expected at least 2 events, got ${events.size}", events.size >= 2)
+        assertTrue("First event should be Cleared, got ${events[0]}", events[0] is AdResult.Cleared)
+        assertTrue("Second event should be Filled, got ${events[1]}", events[1] is AdResult.Filled)
+        val filled = events[1] as AdResult.Filled
+        // The ad binds to the assistant message (afterAssistantMessage position).
+        assertTrue(filled.ads.containsKey("a-1"))
+    }
+
+    @Test
+    fun `preload skip response emits NoFill with skipCode`() {
+        coEvery { repo.preload(any(), any(), any(), any(), any(), any()) } returns ApiResponse.Success(
+            PreloadResult(
+                bids = null, sessionId = "s",
+                remoteLogLevel = null, preloadTimeout = null,
+                skip = true, skipCode = "rate_limit",
+            ),
+        )
+
+        val provider = provider()
+        val events = provider.ads.collectN(2, timeoutMs = 5_000) {
+            provider.setMessages(listOf(userMsg("u-1")))
+            delay(1_600)
+        }
+
+        assertTrue("Expected >=2 events", events.size >= 2)
+        assertTrue(events[0] is AdResult.Cleared)
+        val noFill = events[1] as AdResult.NoFill
+        assertEquals("rate_limit", noFill.skipCode)
+    }
+
+    @Test
+    fun `empty bids yields NoFill with unfilled_bid`() {
+        coEvery { repo.preload(any(), any(), any(), any(), any(), any()) } returns ApiResponse.Success(
+            PreloadResult(
+                bids = emptyList(), sessionId = "s",
+                remoteLogLevel = null, preloadTimeout = null,
+                skip = null, skipCode = null,
+            ),
+        )
+
+        val provider = provider()
+        val events = provider.ads.collectN(2, timeoutMs = 5_000) {
+            provider.setMessages(listOf(userMsg("u-1")))
+            delay(1_600)
+        }
+        assertTrue("Expected >=2 events", events.size >= 2)
+        val noFill = events[1] as AdResult.NoFill
+        assertEquals("unfilled_bid", noFill.skipCode)
+    }
+
+    // ---- Preload errors ----
+
+    @Test
+    fun `network error emits AdResult_Error`() {
+        coEvery { repo.preload(any(), any(), any(), any(), any(), any()) } returns ApiResponse.Error(
+            ApiError.Connection(IOException("dns")),
+        )
+
+        val provider = provider()
+        val events = provider.ads.collectN(2, timeoutMs = 5_000) {
+            provider.setMessages(listOf(userMsg("u-1")))
+            delay(1_600)
+        }
+        assertTrue("Expected >=2 events", events.size >= 2)
+        assertTrue(events[0] is AdResult.Cleared)
+        assertTrue(events[1] is AdResult.Error)
+    }
+
+    // ---- isDisabled forwarding ----
+
+    @Test
+    fun `setMessages propagates the current isDisabled flag to the repository`() {
+        val isDisabledSlot = slot<Boolean>()
+        coEvery {
+            repo.preload(any(), any(), any(), any(), any(), capture(isDisabledSlot))
+        } returns ApiResponse.Success(
+            PreloadResult(null, "s", null, null, null, null),
+        )
+
+        val provider = provider(config(isDisabled = true))
+        // The preload runs only when the flow is being collected — AdsProviderImpl's
+        // pipeline is a cold flow. Collecting the first 2 events is enough to
+        // trigger one preload.
+        provider.ads.collectN(2, timeoutMs = 5_000) {
+            provider.setMessages(listOf(userMsg("u-1")))
+            delay(1_600)
+        }
+
+        assertTrue(isDisabledSlot.isCaptured)
+        assertEquals(true, isDisabledSlot.captured)
+    }
+
+    // ---- Same user message does not re-preload ----
+
+    @Test
+    fun `setting the same last-user message twice does not trigger a second preload`() {
+        coEvery { repo.preload(any(), any(), any(), any(), any(), any()) } returns ApiResponse.Success(
+            PreloadResult(null, "s", null, null, null, null),
+        )
+
+        val provider = provider()
+        provider.ads.collectN(4, timeoutMs = 5_000) {
+            provider.setMessages(listOf(userMsg("u-1")))
+            delay(1_600)
+            provider.setMessages(listOf(userMsg("u-1"))) // same id — no new preload
+            delay(1_000)
+        }
+
+        coVerify(exactly = 1) { repo.preload(any(), any(), any(), any(), any(), any()) }
+    }
+}

--- a/ads/src/test/kotlin/so/kontext/ads/internal/ui/IFrameEventParserTest.kt
+++ b/ads/src/test/kotlin/so/kontext/ads/internal/ui/IFrameEventParserTest.kt
@@ -1,0 +1,242 @@
+package so.kontext.ads.internal.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import so.kontext.ads.internal.ui.model.IFrameEvent
+
+/**
+ * Runs under Robolectric so `org.json.JSONObject` (Android-only) is real.
+ */
+@RunWith(RobolectricTestRunner::class)
+class IFrameEventParserTest {
+
+    private val parser = IFrameEventParser()
+
+    @Test
+    fun `init-iframe parses to InitIframe`() {
+        assertTrue(parser.parse("""{"type": "init-iframe"}""") is IFrameEvent.InitIframe)
+    }
+
+    @Test
+    fun `show-iframe parses to ShowIframe`() {
+        assertTrue(parser.parse("""{"type": "show-iframe"}""") is IFrameEvent.ShowIframe)
+    }
+
+    @Test
+    fun `hide-iframe parses to HideIframe`() {
+        assertTrue(parser.parse("""{"type": "hide-iframe"}""") is IFrameEvent.HideIframe)
+    }
+
+    @Test
+    fun `resize-iframe parses height as float`() {
+        val event = parser.parse("""{"type": "resize-iframe", "data": {"height": 240.5}}""")
+        assertTrue(event is IFrameEvent.Resize)
+        assertEquals(240.5f, (event as IFrameEvent.Resize).height, 0.01f)
+    }
+
+    @Test
+    fun `resize-iframe without data falls back to Unknown`() {
+        val event = parser.parse("""{"type": "resize-iframe"}""")
+        assertTrue(event is IFrameEvent.Unknown)
+    }
+
+    @Test
+    fun `view-iframe populates id content messageId`() {
+        val event = parser.parse(
+            """{"type": "view-iframe", "data": {"id": "b-1", "content": "ad", "messageId": "m-1"}}""",
+        )
+        assertTrue(event is IFrameEvent.View)
+        event as IFrameEvent.View
+        assertEquals("b-1", event.id)
+        assertEquals("ad", event.content)
+        assertEquals("m-1", event.messageId)
+    }
+
+    @Test
+    fun `click-iframe populates id content messageId url`() {
+        val event = parser.parse(
+            """{"type": "click-iframe", "data": {"id": "b-1", "content": "ad", "messageId": "m-1", "url": "https://x"}}""",
+        )
+        assertTrue(event is IFrameEvent.Click)
+        assertEquals("https://x", (event as IFrameEvent.Click).url)
+    }
+
+    @Test
+    fun `ad-done-iframe parses fields`() {
+        val event = parser.parse(
+            """{"type": "ad-done-iframe", "data": {"id": "b", "content": "c", "messageId": "m"}}""",
+        )
+        assertTrue(event is IFrameEvent.AdDone)
+    }
+
+    @Test
+    fun `ad-done-component-iframe parses to AdDoneComponent singleton`() {
+        assertTrue(parser.parse("""{"type": "ad-done-component-iframe"}""") is IFrameEvent.AdDoneComponent)
+    }
+
+    @Test
+    fun `error-iframe parses the top-level message`() {
+        val event = parser.parse("""{"type": "error-iframe", "message": "boom"}""")
+        assertTrue(event is IFrameEvent.Error)
+        assertEquals("boom", (event as IFrameEvent.Error).message)
+    }
+
+    @Test
+    fun `error-iframe without message uses default Unknown error string`() {
+        val event = parser.parse("""{"type": "error-iframe"}""")
+        assertEquals("Unknown error", (event as IFrameEvent.Error).message)
+    }
+
+    @Test
+    fun `open-component-iframe for modal parses code + timeout`() {
+        val event = parser.parse(
+            """{"type": "open-component-iframe", "data": {"code": "inlineAd", "component": "modal", "timeout": 3000}}""",
+        )
+        assertTrue(event is IFrameEvent.OpenComponent)
+        event as IFrameEvent.OpenComponent
+        assertEquals("inlineAd", event.code)
+        assertEquals("modal", event.component)
+        assertEquals(3000, event.timeout)
+    }
+
+    @Test
+    fun `open-component-iframe for non-modal component falls back to Unknown`() {
+        val event = parser.parse(
+            """{"type": "open-component-iframe", "data": {"code": "c", "component": "popup"}}""",
+        )
+        assertTrue(event is IFrameEvent.Unknown)
+    }
+
+    @Test
+    fun `init-component close-component error-component parse matching modal events`() {
+        assertTrue(
+            parser.parse(
+                """{"type": "init-component-iframe", "data": {"code": "c", "component": "modal"}}""",
+            ) is IFrameEvent.InitComponent,
+        )
+        assertTrue(
+            parser.parse(
+                """{"type": "close-component-iframe", "data": {"code": "c", "component": "modal"}}""",
+            ) is IFrameEvent.CloseComponent,
+        )
+        assertTrue(
+            parser.parse(
+                """{"type": "error-component-iframe", "data": {"code": "c", "component": "modal"}}""",
+            ) is IFrameEvent.ErrorComponent,
+        )
+    }
+
+    @Test
+    fun `event-iframe ad_viewed parses CallbackEvent_Viewed`() {
+        val event = parser.parse(
+            """
+            {
+              "type": "event-iframe",
+              "data": {
+                "name": "ad.viewed",
+                "code": "inlineAd",
+                "payload": {"id": "b", "content": "c", "messageId": "m", "format": "inline"}
+              }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(event is IFrameEvent.CallbackEvent.Viewed)
+        val viewed = event as IFrameEvent.CallbackEvent.Viewed
+        assertEquals("b", viewed.bidId)
+        assertEquals("inline", viewed.format)
+    }
+
+    @Test
+    fun `event-iframe ad_clicked parses CallbackEvent_Clicked with url + format + area`() {
+        val event = parser.parse(
+            """
+            {
+              "type": "event-iframe",
+              "data": {
+                "name": "ad.clicked",
+                "code": "inlineAd",
+                "payload": {
+                  "id": "b", "content": "c", "messageId": "m",
+                  "url": "https://x", "format": "inline", "area": "cta"
+                }
+              }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(event is IFrameEvent.CallbackEvent.Clicked)
+        val clicked = event as IFrameEvent.CallbackEvent.Clicked
+        assertEquals("https://x", clicked.url)
+        assertEquals("cta", clicked.area)
+    }
+
+    @Test
+    fun `event-iframe render-started and render-completed parse`() {
+        val started = parser.parse(
+            """{"type": "event-iframe", "data": {"name": "ad.render-started", "code": "c", "payload": {"id": "b"}}}""",
+        )
+        val completed = parser.parse(
+            """{"type": "event-iframe", "data": {"name": "ad.render-completed", "code": "c", "payload": {"id": "b"}}}""",
+        )
+        assertTrue(started is IFrameEvent.CallbackEvent.RenderStarted)
+        assertTrue(completed is IFrameEvent.CallbackEvent.RenderCompleted)
+    }
+
+    @Test
+    fun `event-iframe ad_error parses CallbackEvent_Error with message + errCode`() {
+        val event = parser.parse(
+            """
+            {"type": "event-iframe", "data": {"name": "ad.error", "code": "c", "payload": {"message": "boom", "errCode": "E42"}}}
+            """.trimIndent(),
+        )
+        assertTrue(event is IFrameEvent.CallbackEvent.Error)
+        val err = event as IFrameEvent.CallbackEvent.Error
+        assertEquals("boom", err.message)
+        assertEquals("E42", err.errCode)
+    }
+
+    @Test
+    fun `event-iframe reward_granted video_started video_completed parse`() {
+        val reward = parser.parse(
+            """{"type": "event-iframe", "data": {"name": "reward.granted", "code": "c", "payload": {"id": "b"}}}""",
+        )
+        val started = parser.parse(
+            """{"type": "event-iframe", "data": {"name": "video.started", "code": "c", "payload": {"id": "b"}}}""",
+        )
+        val completed = parser.parse(
+            """{"type": "event-iframe", "data": {"name": "video.completed", "code": "c", "payload": {"id": "b"}}}""",
+        )
+        assertTrue(reward is IFrameEvent.CallbackEvent.RewardGranted)
+        assertTrue(started is IFrameEvent.CallbackEvent.VideoStarted)
+        assertTrue(completed is IFrameEvent.CallbackEvent.VideoCompleted)
+    }
+
+    @Test
+    fun `event-iframe with unknown name falls back to Generic with payload map`() {
+        val event = parser.parse(
+            """
+            {"type": "event-iframe", "data": {"name": "custom.event", "code": "c", "payload": {"foo": "bar", "n": 1}}}
+            """.trimIndent(),
+        )
+        assertTrue(event is IFrameEvent.CallbackEvent.Generic)
+        val generic = event as IFrameEvent.CallbackEvent.Generic
+        assertEquals("c", generic.code)
+        assertEquals("bar", generic.payload["foo"])
+    }
+
+    @Test
+    fun `unknown type falls back to Unknown`() {
+        val event = parser.parse("""{"type": "something-new"}""")
+        assertTrue(event is IFrameEvent.Unknown)
+        assertEquals("something-new", (event as IFrameEvent.Unknown).type)
+    }
+
+    @Test
+    fun `malformed JSON falls back to Unknown with parse-error type`() {
+        val event = parser.parse("not-json")
+        assertTrue(event is IFrameEvent.Unknown)
+        assertEquals("parse-error", (event as IFrameEvent.Unknown).type)
+    }
+}

--- a/ads/src/test/kotlin/so/kontext/ads/internal/utils/consent/TcfInfoGetTcfDataTest.kt
+++ b/ads/src/test/kotlin/so/kontext/ads/internal/utils/consent/TcfInfoGetTcfDataTest.kt
@@ -1,0 +1,98 @@
+package so.kontext.ads.internal.utils.consent
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Runs under Robolectric so `PreferenceManager.getDefaultSharedPreferences(context)`
+ * returns a real `SharedPreferences` implementation.
+ */
+@RunWith(RobolectricTestRunner::class)
+class TcfInfoGetTcfDataTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @After
+    fun tearDown() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    @Test
+    fun `returns all-null TcfData when no TCF keys are present`() {
+        val data = TcfInfo.getTcfData(context)
+        assertNull(data.gdpr)
+        assertNull(data.gdprConsent)
+    }
+
+    @Test
+    fun `reads gdprApplies=1 and a non-empty tcString`() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putInt("IABTCF_gdprApplies", 1)
+            .putString("IABTCF_TCString", "CONSENT-STRING")
+            .commit()
+
+        val data = TcfInfo.getTcfData(context)
+        assertEquals(1, data.gdpr)
+        assertEquals("CONSENT-STRING", data.gdprConsent)
+    }
+
+    @Test
+    fun `reads gdprApplies=0`() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putInt("IABTCF_gdprApplies", 0)
+            .commit()
+        assertEquals(0, TcfInfo.getTcfData(context).gdpr)
+    }
+
+    @Test
+    fun `gdprApplies outside 0 or 1 is treated as null`() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putInt("IABTCF_gdprApplies", 5)
+            .commit()
+        assertNull(TcfInfo.getTcfData(context).gdpr)
+    }
+
+    @Test
+    fun `empty tcString is treated as null`() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putString("IABTCF_TCString", "")
+            .commit()
+        assertNull(TcfInfo.getTcfData(context).gdprConsent)
+    }
+
+    @Test
+    fun `gdprApplies stored as a numeric string is read via the string fallback`() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putString("IABTCF_gdprApplies", "1")
+            .commit()
+        assertEquals(1, TcfInfo.getTcfData(context).gdpr)
+    }
+
+    @Test
+    fun `gdprApplies stored as a non-numeric string is treated as null`() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putString("IABTCF_gdprApplies", "not-a-number")
+            .commit()
+        assertNull(TcfInfo.getTcfData(context).gdpr)
+    }
+
+    @Test
+    fun `missing gdprApplies key with a valid tcString only populates gdprConsent`() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putString("IABTCF_TCString", "CONSENT")
+            .commit()
+        val data = TcfInfo.getTcfData(context)
+        assertNull(data.gdpr)
+        assertEquals("CONSENT", data.gdprConsent)
+    }
+}

--- a/ads/src/test/kotlin/so/kontext/ads/internal/utils/deviceinfo/DeviceInfoProviderTest.kt
+++ b/ads/src/test/kotlin/so/kontext/ads/internal/utils/deviceinfo/DeviceInfoProviderTest.kt
@@ -1,0 +1,102 @@
+package so.kontext.ads.internal.utils.deviceinfo
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import so.kontext.ads.internal.AdsProperties
+
+/**
+ * Smoke-level tests for DeviceInfoProvider — verifies that it can instantiate
+ * and produce a well-formed DeviceInfo under Robolectric without throwing.
+ *
+ * Per-collector accuracy is platform-dependent and doesn't round-trip
+ * cleanly without a real device. We only assert shape + invariants.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DeviceInfoProviderTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `can be constructed under Robolectric`() {
+        val provider = DeviceInfoProvider(context)
+        assertNotNull(provider)
+    }
+
+    @Test
+    fun `deviceInfo returns a non-null snapshot with every sub-info populated`() {
+        val info = DeviceInfoProvider(context).deviceInfo
+        assertNotNull(info.osInfo)
+        assertNotNull(info.hardwareInfo)
+        assertNotNull(info.screenInfo)
+        assertNotNull(info.powerInfo)
+        assertNotNull(info.audioInfo)
+        assertNotNull(info.networkInfo)
+        assertNotNull(info.appInfo)
+        assertNotNull(info.sdkInfo)
+    }
+
+    @Test
+    fun `sdkInfo exposes the configured SDK name and platform`() {
+        val info = DeviceInfoProvider(context).deviceInfo
+        assertEquals(AdsProperties.SdkName, info.sdkInfo.sdkName)
+        assertEquals(AdsProperties.PlatformName, info.sdkInfo.sdkPlatform)
+        // Version comes from BuildConfig — we only assert it's non-empty.
+        assertTrue(info.sdkInfo.sdkVersion.isNotEmpty())
+    }
+
+    @Test
+    fun `osInfo has a valid os name and a non-empty timezone`() {
+        val os = DeviceInfoProvider(context).deviceInfo.osInfo
+        assertTrue(os.osName.isNotEmpty())
+        assertTrue(os.osVersion.isNotEmpty())
+        assertTrue(os.locale.isNotEmpty())
+        assertTrue(os.timezone.isNotEmpty())
+    }
+
+    @Test
+    fun `hardwareInfo reports a DeviceType`() {
+        val hw = DeviceInfoProvider(context).deviceInfo.hardwareInfo
+        assertTrue(hw.type in DeviceType.entries)
+    }
+
+    @Test
+    fun `screenInfo reports non-negative dimensions and a valid orientation`() {
+        val screen = DeviceInfoProvider(context).deviceInfo.screenInfo
+        assertTrue(screen.screenWidth >= 0)
+        assertTrue(screen.screenHeight >= 0)
+        assertTrue(screen.dpr >= 0f)
+        assertTrue(screen.screenOrientation in ScreenOrientation.entries)
+    }
+
+    @Test
+    fun `powerInfo batteryState is a known BatteryState value`() {
+        val power = DeviceInfoProvider(context).deviceInfo.powerInfo
+        assertTrue(power.batteryState in BatteryState.entries)
+    }
+
+    @Test
+    fun `appInfo produces a non-null bundleId`() {
+        val app = DeviceInfoProvider(context).deviceInfo.appInfo
+        // Under Robolectric the bundleId defaults to the test package — just
+        // assert the provider doesn't throw and returns a non-null string.
+        assertNotNull(app.appBundleId)
+    }
+
+    @Test
+    fun `two consecutive deviceInfo reads return equivalent snapshots`() {
+        val provider = DeviceInfoProvider(context)
+        val a = provider.deviceInfo
+        val b = provider.deviceInfo
+        // Static info comes from a lazy, so these fields should be identical.
+        assertEquals(a.osInfo.osName, b.osInfo.osName)
+        assertEquals(a.hardwareInfo.brand, b.hardwareInfo.brand)
+        assertEquals(a.sdkInfo.sdkVersion, b.sdkInfo.sdkVersion)
+        assertEquals(a.appInfo.appBundleId, b.appInfo.appBundleId)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ recyclerview = "1.4.0"
 material = "1.12.0"
 junit-jupiter = "5.10.0"
 mockk = "1.13.8"
+robolectric = "4.11.1"
 play-services-ads-identifier = "18.1.0"
 preference = "1.2.1"
 
@@ -45,6 +46,8 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+androidx-test-core = { group = "androidx.test", name = "core", version = "1.5.0" }
 
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }


### PR DESCRIPTION
## Summary

Adds Robolectric to the `:ads` unit test classpath so Android framework classes (Context, SharedPreferences, `org.json.JSONObject`, system services) work inside JVM unit tests without needing an emulator. Unlocks coverage of four previously-untestable files:

| Area | New tests | File |
|---|---|---|
| IFrameEventParser (org.json) | 22 | `internal/ui/IFrameEventParserTest.kt` |
| TcfInfo.getTcfData (SharedPreferences) | 8 | `internal/utils/consent/TcfInfoGetTcfDataTest.kt` |
| AdsProviderImpl (orchestrator) | 6 | `internal/AdsProviderImplTest.kt` |
| DeviceInfoProvider (system services) | 9 | `internal/utils/deviceinfo/DeviceInfoProviderTest.kt` |

Total: **141 → 186 tests**. No changes to production code.

## Configuration

- `android.testOptions.unitTests.isIncludeAndroidResources = true` (Robolectric needs the manifest + resources).
- JUnit Platform now runs both `junit-jupiter` (existing JUnit 5 suite) and `junit-vintage` (Robolectric is JUnit 4).
- New test-only deps: `robolectric:4.11.1`, `androidx.test:core:1.5.0`, `junit:4.13.2`, `junit-vintage-engine` matching the Jupiter version.

## What's covered now

**IFrameEventParser** (previously skipped — relied on Android's `org.json.JSONObject`):
- Every simple event type (`init-iframe`, `show-iframe`, `hide-iframe`, `ad-done-iframe`, `ad-done-component-iframe`)
- Field-level parsing for `resize-iframe` (height), `view-iframe`, `click-iframe`, `ad-done-iframe`, `error-iframe` (message + default)
- Every `*-component-iframe` variant (open/init/close/error) and the modal-only gate
- Every `event-iframe` callback name (ad.viewed/clicked/render-started/render-completed/ad.error/reward.granted/video.started/video.completed)
- Unknown event names fall back to `Generic` with the raw payload map
- Unknown top-level types and malformed JSON produce `Unknown(parse-error, …)`

**TcfInfo.getTcfData**:
- Default empty `SharedPreferences` → null data
- `gdprApplies=1` + non-empty `tcString` → populated
- `gdprApplies=0` → 0
- Out-of-range gdpr value → null
- Empty tcString → null
- Numeric string fallback when gdprApplies is stored as a string
- Non-numeric string → null
- Missing gdpr key + valid tcString → only gdprConsent populated

**AdsProviderImpl** (previously skipped — needed Context + DeviceInfoProvider + AdsModule):
- New user message triggers preload → emits `Cleared` then `Filled` with per-message ad map
- Skip response emits `NoFill` with the server's `skipCode`
- Empty bids yields `NoFill("unfilled_bid")`
- Network error emits `AdResult.Error`
- `isDisabled` forwards to `AdsRepository.preload`
- Duplicate last-user-message does not re-preload

**DeviceInfoProvider** smoke coverage:
- Constructor under Robolectric doesn't throw
- Full snapshot returns non-null sub-infos
- SDK name + platform identity from `AdsProperties`
- OS/hardware/screen/power/network field invariants
- Memoized static info across two reads

## Running

```bash
./gradlew :ads:testDebug
./gradlew spotlessCheck detekt  # both still clean
```

## Test plan

- [x] Locally: 186/186 green in ~1 min (Robolectric bootstrap takes ~30s on first run)
- [x] `spotlessCheck` + `detekt` + `testDebug` all pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)