### PR TITLE
Release 2.0.1: bump Ktor to 3.2.3 (+ Kotlin 2.1.0)

### DIFF
--- a/ads/build.gradle.kts
+++ b/ads/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.maven.publish)
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.spotless)
     alias(libs.plugins.detekt)
@@ -31,10 +32,6 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
     }
 
     buildTypes {

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -4,6 +4,7 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.spotless)
     alias(libs.plugins.detekt)
 }
@@ -55,10 +56,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
     }
 
     kotlinOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
-sdkkotlin = "2.0.0"
+sdkkotlin = "2.0.1"
 
-agp = "8.1.4"
-kotlin = "1.9.0"
+agp = "8.7.3"
+kotlin = "2.1.0"
 lifecycleRuntimeKtx = "2.7.0"
 activityCompose = "1.8.2"
 coreKtx = "1.12.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-composeBom = "2023.08.00"
-ktor = "2.3.7"
-kotlinx-serialization = "1.6.3"
-coroutines = "1.8.1"
+composeBom = "2024.12.01"
+ktor = "3.2.3"
+kotlinx-serialization = "1.7.3"
+coroutines = "1.9.0"
 koin = "3.5.4"
 maven-publish = "0.34.0"
 ktlint = "0.50.0"
@@ -83,6 +83,7 @@ koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compos
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Aug 11 16:57:10 CEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

Customer hotfix: another ad SDK in the publisher's app pulled `io.ktor` up to **3.2.3**, conflicting at runtime with our `2.3.7`. They asked for a 2.0.x release with Ktor 3.2.3 or they'll drop the integration. Ktor 3.x requires Kotlin 2.0+, so Kotlin moves to **2.1.0** at the same time (matching the customer's Kotlin version, per chat agreement).

Branched from tag `2.0.0` — **not** from `main`. `main` has changes (KON-1714 OMID compliance, Robolectric coverage, etc.) that we don't want to ship in a customer hotfix.

## Changes

- `ktor` 2.3.7 → **3.2.3**
- `kotlin` 1.9.0 → **2.1.0**
- `agp` 8.1.4 → 8.7.3 (Kotlin 2.1 compat)
- `gradle` wrapper 8.5 → 8.9 (AGP 8.7 compat)
- `composeBom` 2023.08.00 → 2024.12.01
- `kotlinx-serialization` 1.6.3 → 1.7.3
- `coroutines` 1.8.1 → 1.9.0
- Compose Compiler: removed `composeOptions { kotlinCompilerExtensionVersion = "1.5.1" }`, switched to the `org.jetbrains.kotlin.plugin.compose` Gradle plugin (required from Kotlin 2.x)

**No source code changes.** The Ktor 3.x client API we depend on (`HttpClient`, `ContentNegotiation`, `HttpTimeout`, `Logging`, `defaultRequest`, and the three exception types in `ApiCall.kt`) is identical to 2.3.7 at our usage surface.

## Test plan

- [x] `./gradlew :ads:assembleRelease` — BUILD SUCCESSFUL
- [x] `./gradlew :ads:test` — passing
- [x] `./gradlew :ads:detekt :ads:spotlessCheck` — clean
- [x] `./gradlew :example:assembleDebug` — BUILD SUCCESSFUL
- [x] Publish to Maven Local and verify `so.kontext:ads:2.0.1` resolves with `io.ktor:*:3.2.3`
- [x] Smoke test in the example app on a physical device
- [ ] Confirm with customer that the runtime conflict is resolved

## Note for reviewers

Do not merge yet — waiting for further instructions before publishing to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)