### PR TITLE
Add 2.0.1 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+* Bump Ktor from 2.3.7 to 3.2.3.
+* Bump Kotlin from 1.9.0 to 2.1.0 (required by Ktor 3.x).
+
 ## 2.0.0
 ### Breaking
 `AdResult` sealed interface updated: `Success` renamed to `Filled`, and `NoFill` added as a distinct state separate from `Error`. Update exhaustive `when` expressions to handle the new `.NoFill` case.


### PR DESCRIPTION
## Summary

Retroactive CHANGELOG entry for 2.0.1, which was published to Maven Central before this file had a row for it (the `release/2.0.1` branch was cut from the `2.0.0` tag, predating CHANGELOG.md in main).

## Test plan

- [x] Visual diff of CHANGELOG.md — entry inserted between header and `## 2.0.0` in the existing bullet style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)