### PR TITLE
Release version 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.0.2
+
+Lower `minSdk` to 24.
+
+* `minSdk` 26 → 24 (Android 8.0 Oreo → Android 7.0 Nougat). Nothing in the SDK requires API 26 — no `@RequiresApi` gates, no `java.time` usage — so the floor is lowered to widen device support. No public API changes.
+* Bump KontextKit dependency to `0.0.7`, which also lowers its `minSdk` to 24 so the manifest merge stays consistent for consumers.
+
 ## 4.0.1
 
 IAB OMID AAR now flows in transitively from KontextKit — no more local vendoring required on customer builds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## 4.0.2
 
-Lower `minSdk` to 24.
+Lower `minSdk` to 24 and fix inline (display) OMID sessions.
 
 * `minSdk` 26 → 24 (Android 8.0 Oreo → Android 7.0 Nougat). Nothing in the SDK requires API 26 — no `@RequiresApi` gates, no `java.time` usage — so the floor is lowered to widen device support. No public API changes.
 * Bump KontextKit dependency to `0.0.7`, which also lowers its `minSdk` to 24 so the manifest merge stays consistent for consumers.
+* Fix inline OMID sessions for display (banner) ads. `restartOmSessionIfRetired` fired on a fresh ad's first mount — i.e. *before* `ad-done` — so the OMID session started before the iframe and its verification script had loaded. The in-iframe script never dispatched `sessionStart`/`impression`, and teardown emitted a bare `sessionFinish` with no preceding start. The inline session now starts only from `ad-done` (iframe ready); a genuine scroll-off/scroll-back still restarts a previously-started session. Interstitial/video OMID was unaffected.
 
 ## 4.0.1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Kontext Kotlin SDK — an Android SDK for integrating AI-powered contextual ads 
 
 ## Modules
 
-- **`:ads`** — the publishable SDK library (min SDK 26, JVM 17)
+- **`:ads`** — the publishable SDK library (min SDK 24, JVM 17)
 - **`:example`** — demo Android app showing v4 integration (single `MainActivity` with a chat-like UI that calls `KontextAds.createSession(...)` and renders `InlineAd`s)
 
 ## Common Commands
@@ -38,7 +38,7 @@ Kontext Kotlin SDK — an Android SDK for integrating AI-powered contextual ads 
 
 ## Architecture
 
-The v4 SDK delivers AI-powered ads into Android chat UIs. Distributed via Maven Central. Min SDK 26, compileSdk 36, JVM 17.
+The v4 SDK delivers AI-powered ads into Android chat UIs. Distributed via Maven Central. Min SDK 24, compileSdk 36, JVM 17.
 
 ### Entry Point & Public API (`ads/src/main/kotlin/so/kontext/ads/`)
 

--- a/ads/build.gradle.kts
+++ b/ads/build.gradle.kts
@@ -32,8 +32,8 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        // Minimum runtime API. Android 8.0 (Oreo).
-        minSdk = 26
+        // Minimum runtime API. Android 7.0 (Nougat).
+        minSdk = 24
 
         // ProGuard rules packaged into the .aar; auto-applied during
         // the consuming app's R8 pass.

--- a/ads/src/main/kotlin/so/kontext/ads/Ad.kt
+++ b/ads/src/main/kotlin/so/kontext/ads/Ad.kt
@@ -444,6 +444,19 @@ public class Ad internal constructor(
     private var omSession: OmSession? = null
 
     /**
+     * True once an inline OMID session has been successfully started at
+     * least once (only happens from `handleAdDone`, after the iframe +
+     * its verification script have loaded). Gates
+     * [restartOmSessionIfRetired]: a *fresh* ad must NOT start OMID on its
+     * first mount — the iframe isn't ready, so the native session would
+     * start before the JS can fire `sessionStart`, and teardown would emit
+     * a bare `sessionFinish` with no preceding start. Only a genuine
+     * scroll-off/scroll-back (where a session already existed and was
+     * retired) should restart.
+     */
+    private var omEverStarted = false
+
+    /**
      * Pending dispose. When the InlineAd composable leaves composition we
      * don't destroy immediately — LazyColumn recycling re-mounts the same
      * Ad almost instantly. After [PENDING_DESTROY_DELAY_MS] without a
@@ -466,6 +479,7 @@ public class Ad internal constructor(
                     session.scopeOnMain.launch {
                         val newSession = omManager.createSession(webView, iframeUrl, creativeType)
                         omSession = newSession
+                        if (newSession != null) omEverStarted = true
                         session.debug(
                             "Ad: om-session-started",
                             mapOf("messageId" to messageId, "valid" to (newSession != null)),
@@ -531,6 +545,11 @@ public class Ad internal constructor(
     internal fun restartOmSessionIfRetired() {
         if (destroyed) return
         if (omSession != null) return
+        // Fresh ad (never started OMID): defer to `handleAdDone` so the
+        // session starts only after the iframe + verification script load.
+        // Restarting here would start OMID before `ad-done` and the JS
+        // would never fire `sessionStart`.
+        if (!omEverStarted) return
         if (bid == null || adWebView == null) return
         startOmSessionDelayed()
     }

--- a/ads/src/test/kotlin/so/kontext/ads/ConfigurationTest.kt
+++ b/ads/src/test/kotlin/so/kontext/ads/ConfigurationTest.kt
@@ -162,7 +162,7 @@ class ConfigurationTest {
     @Test
     fun `constants have expected values`() {
         assertEquals("sdk-kotlin", SDKInfo.NAME)
-        assertEquals("4.0.1", SDKInfo.VERSION)
+        assertEquals("4.0.2", SDKInfo.VERSION)
         assertEquals("android", SDKInfo.PLATFORM)
         assertEquals(30, Constants.MAX_MESSAGES)
     }

--- a/ads/src/test/kotlin/so/kontext/ads/PreloadTest.kt
+++ b/ads/src/test/kotlin/so/kontext/ads/PreloadTest.kt
@@ -198,7 +198,7 @@ class PreloadTest {
 
         val dto = json.decodeFromString<PreloadRequestDto>(capturedBody!!)
         assertEquals("sdk-kotlin", dto.sdk.name)
-        assertEquals("4.0.1", dto.sdk.version)
+        assertEquals("4.0.2", dto.sdk.version)
         assertEquals("android", dto.sdk.platform)
     }
 

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 
     defaultConfig {
         applicationId = "so.kontext.ads.example"
-        minSdk = 26
+        minSdk = 24
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,12 +11,12 @@
 # `./gradlew :ads:publish -PsdkVersion=4.1.0` so CI can cut patch
 # releases without bumping this file. Read at runtime as
 # `BuildConfig.SDK_VERSION` (see ads/build.gradle.kts).
-sdk-kotlin = "4.0.1"
+sdk-kotlin = "4.0.2"
 
 # ---- KontextKit ----
 # Shared device-info / privacy / UI / OMID library, published to
 # Maven Central from github.com/kontextso/kontextkit-android.
-kontext-kit = "0.0.6"
+kontext-kit = "0.0.7"
 
 # ---- Build tooling ----
 agp = "8.7.3"                       # Android Gradle Plugin (compileSdk 36 needs 8.6+; AGP 8.7+ needs Gradle 8.9)


### PR DESCRIPTION
## 4.0.2

Lower `minSdk` to 24 and fix inline (display) OMID sessions.

### minSdk 24
* `minSdk` 26 → 24 (Android 8.0 Oreo → Android 7.0 Nougat) on both `:ads` and `:example`. Nothing in the SDK requires API 26 — no `@RequiresApi` gates, no `java.time` usage — so the floor is lowered to widen device support. No public API changes.
* Bump KontextKit dependency to `0.0.7` (also `minSdk 24`), so the manifest merge stays consistent for consumers.

### Inline OMID fix
* `restartOmSessionIfRetired()` fired on a fresh ad's first mount (via `InlineAd`'s `DisposableEffect`) — i.e. **before `ad-done`** — so the OMID session started before the iframe + its verification script had loaded. The in-iframe script never dispatched `sessionStart`/`impression`, and teardown emitted a bare `sessionFinish` with no session id. Display (banner) ads were affected; interstitial/video (started in `InterstitialAdActivity` on `ad-done-component`) were not.
* Gate the restart on a new `omEverStarted` flag (set only when a session actually starts, which happens from `ad-done`). A fresh ad now starts OMID from `ad-done` with the iframe ready; a genuine scroll-off/scroll-back still restarts a previously-started session.

### Verification
* `spotlessCheck detekt assembleDebug testDebug` green (289 tests, 0 failures).
* Manually verified on emulator against the **published** `kontext-kit-android:0.0.7` (minSdk 24): display ads now emit a full OMID `sessionStart → impression → … → sessionFinish`; interstitial/video unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)