### PR TITLE
example: multi-Activity character-switch flow to reproduce the OMID TreeWalker crash

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -20,15 +20,25 @@
         android:theme="@android:style/Theme.Material.Light.NoActionBar"
         android:usesCleartextTraffic="true">
 
-        <!-- Traditional-View RecyclerView screen — the integration shape
-             publishers use from an XML / RecyclerView UI. -->
+        <!-- Launcher: character picker for the character-switch crash repro. -->
         <activity
-            android:name=".MainActivity"
+            android:name=".IntroActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Per-character chat (new Session per entry, closed on Back). The
+             repro flow: open a character, view an ad, Back, open again. -->
+        <activity
+            android:name=".CharacterChatActivity"
+            android:exported="false" />
+
+        <!-- Legacy single-screen RecyclerView demo, reachable from the intro. -->
+        <activity
+            android:name=".MainActivity"
+            android:exported="false" />
     </application>
 </manifest>

--- a/example/src/main/java/so/kontext/ads/example/CharacterChatActivity.kt
+++ b/example/src/main/java/so/kontext/ads/example/CharacterChatActivity.kt
@@ -1,0 +1,177 @@
+package so.kontext.ads.example
+
+import android.os.Bundle
+import android.util.Log
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Switch
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import so.kontext.ads.KontextAds
+import so.kontext.ads.Session
+import so.kontext.ads.model.AddMessageOptions
+import so.kontext.ads.model.AdEvent
+import so.kontext.ads.model.Message
+import so.kontext.ads.model.Role
+import so.kontext.ads.model.SessionOptions
+
+/**
+ * Per-character chat screen for the crash repro. Each entry creates its OWN
+ * [Session] (fresh conversationId) and destroys it in [onDestroy] via
+ * `session.close()` — exactly the speakmaster lifecycle: one Activity + one
+ * Session per character, torn down on Back.
+ *
+ * Identical chat mechanics to [MainActivity]; the only difference is that the
+ * screen is reachable from [IntroActivity], parameterized by character, and
+ * always destroyed when the user goes Back — which is what exercises the
+ * process-global OMID teardown across Activities.
+ */
+class CharacterChatActivity : ComponentActivity() {
+
+    private lateinit var session: Session
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_chat)
+
+        val character = intent.getStringExtra(EXTRA_CHARACTER) ?: "Aria"
+        findViewById<TextView>(R.id.characterTitle).text = "Chat with $character"
+
+        val adServerOverride: String? = BuildConfig.AD_SERVER_URL.takeIf { it.isNotBlank() }
+        session = KontextAds.createSession(
+            context = applicationContext,
+            options = SessionOptions(
+                publisherToken = BuildConfig.PUBLISHER_TOKEN,
+                userId = "user-1",
+                // Fresh conversation per character entry — a brand-new Session
+                // each time, so nothing carries over except the process-global
+                // OMID SDK state we're testing.
+                conversationId = "conv-$character-${System.currentTimeMillis()}",
+                adServerUrl = adServerOverride,
+                onEvent = { event -> Log.d("KontextExample", "[$character] Event: $event") },
+                onDebugEvent = { str, data ->
+                    if ((data as? Map<*, *>)?.get("type") != "update-dimensions-iframe") {
+                        Log.d("KontextExample", "[$character] Debug: $str $data")
+                    }
+                },
+            ),
+        )
+
+        val recyclerView: RecyclerView = findViewById(R.id.messagesRecyclerView)
+        val input: EditText = findViewById(R.id.messageEditText)
+        val send: Button = findViewById(R.id.sendButton)
+        val trackOnlySwitch: Switch = findViewById(R.id.trackOnlySwitch)
+        val back: Button = findViewById(R.id.backButton)
+
+        back.setOnClickListener { finish() }
+
+        val adapter = MessageAdapter(session)
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = adapter
+
+        val messages = mutableListOf<ChatMessage>()
+        var counter = 0
+        var loading = false
+
+        fun pinLastItemBottom() {
+            val lm = recyclerView.layoutManager as LinearLayoutManager
+            val last = adapter.itemCount - 1
+            if (last < 0) return
+            val view = lm.findViewByPosition(last) ?: return
+            val overflow = view.bottom - (recyclerView.height - recyclerView.paddingBottom)
+            if (overflow > 0) recyclerView.scrollBy(0, overflow)
+        }
+
+        fun scrollToBottom() {
+            val last = adapter.itemCount - 1
+            if (last < 0) return
+            recyclerView.scrollToPosition(last)
+            recyclerView.post { pinLastItemBottom() }
+        }
+
+        fun isNearBottom(): Boolean {
+            val lm = recyclerView.layoutManager as LinearLayoutManager
+            return lm.findLastVisibleItemPosition() >= adapter.itemCount - 2
+        }
+
+        adapter.onAdResized = {
+            if (isNearBottom()) recyclerView.post { pinLastItemBottom() }
+        }
+
+        fun publish() {
+            val lastAssistantId = messages.lastOrNull { it.role == Role.ASSISTANT }?.id
+            val display = messages.map {
+                it.copy(showAd = !loading && it.role == Role.ASSISTANT && it.id == lastAssistantId)
+            }
+            adapter.submitList(display) { scrollToBottom() }
+        }
+
+        fun sendUserMessage(text: String, trackOnly: Boolean) {
+            counter++
+            val userId = "u$counter"
+            messages.add(ChatMessage(userId, Role.USER, text))
+            loading = true
+            publish()
+            lifecycleScope.launch {
+                session.addMessage(
+                    Message(id = userId, role = Role.USER, content = text),
+                    AddMessageOptions(trackOnly = trackOnly),
+                )
+                delay(500)
+                counter++
+                val assistantId = "a$counter"
+                val reply = "This is a response from the assistant."
+                messages.add(ChatMessage(assistantId, Role.ASSISTANT, reply))
+                loading = false
+                publish()
+                session.addMessage(Message(id = assistantId, role = Role.ASSISTANT, content = reply))
+            }
+        }
+
+        send.setOnClickListener {
+            val text = input.text.toString().trim()
+            if (text.isNotEmpty()) {
+                input.text.clear()
+                sendUserMessage(text, trackOnlySwitch.isChecked)
+            }
+        }
+
+        lifecycleScope.launch {
+            session.events.collect { event ->
+                when (event) {
+                    is AdEvent.Filled, is AdEvent.AdHeight, is AdEvent.RenderCompleted -> {
+                        if (isNearBottom()) recyclerView.post { pinLastItemBottom() }
+                    }
+                    else -> Unit
+                }
+            }
+        }
+
+        // Seed a greeting so the first /preload fires on entry and the reply
+        // shows an ad without the user having to type — makes the repro a
+        // two-tap loop (open character → ad appears → Back → repeat).
+        lifecycleScope.launch {
+            messages.add(ChatMessage("u-seed", Role.USER, "Hi $character!"))
+            messages.add(ChatMessage("a-seed", Role.ASSISTANT, "Hi! I'm $character, your friendly AI companion."))
+            publish()
+            session.addMessage(Message(id = "u-seed", role = Role.USER, content = "Hi $character!"))
+            session.addMessage(
+                Message(id = "a-seed", role = Role.ASSISTANT, content = "Hi! I'm $character, your friendly AI companion."),
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        session.close()
+    }
+
+    companion object {
+        const val EXTRA_CHARACTER: String = "character"
+    }
+}

--- a/example/src/main/java/so/kontext/ads/example/IntroActivity.kt
+++ b/example/src/main/java/so/kontext/ads/example/IntroActivity.kt
@@ -1,0 +1,42 @@
+package so.kontext.ads.example
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import androidx.activity.ComponentActivity
+
+/**
+ * Launcher screen for the character-switch crash repro.
+ *
+ * Lists three characters; tapping one opens [CharacterChatActivity] on a
+ * fresh [so.kontext.ads.Session]. The reproduction is: open a character →
+ * view a Kontext ad → press Back (the chat Activity is destroyed and
+ * `session.close()` runs) → open any character again → the app crashes in
+ * OMID's TreeWalker when the next ad reaches its display timing.
+ *
+ * Mirrors the speakmaster flow: one Activity (and one Session) per character
+ * entry, destroyed on exit, with a process-global OMID SDK surviving across
+ * Activities.
+ */
+class IntroActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_intro)
+
+        fun openCharacter(name: String) {
+            startActivity(
+                Intent(this, CharacterChatActivity::class.java)
+                    .putExtra(CharacterChatActivity.EXTRA_CHARACTER, name),
+            )
+        }
+
+        findViewById<Button>(R.id.characterAria).setOnClickListener { openCharacter("Aria") }
+        findViewById<Button>(R.id.characterMilo).setOnClickListener { openCharacter("Milo") }
+        findViewById<Button>(R.id.characterNova).setOnClickListener { openCharacter("Nova") }
+
+        findViewById<Button>(R.id.legacyDemo).setOnClickListener {
+            startActivity(Intent(this, MainActivity::class.java))
+        }
+    }
+}

--- a/example/src/main/res/layout/activity_chat.xml
+++ b/example/src/main/res/layout/activity_chat.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/chat"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingHorizontal="12dp"
+        android:paddingTop="12dp">
+
+        <Button
+            android:id="@+id/backButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Back" />
+
+        <TextView
+            android:id="@+id/characterTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingStart="12dp"
+            android:text="Chat"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingHorizontal="12dp"
+        android:paddingTop="8dp">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Track only (analytics, no ad fill)"
+            android:textSize="14sp" />
+
+        <Switch
+            android:id="@+id/trackOnlySwitch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/messagesRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="8dp" />
+
+    <LinearLayout
+        android:id="@+id/inputLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="12dp">
+
+        <EditText
+            android:id="@+id/messageEditText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="Type a message..."
+            android:importantForAutofill="no"
+            android:inputType="text" />
+
+        <Button
+            android:id="@+id/sendButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send" />
+    </LinearLayout>
+</LinearLayout>

--- a/example/src/main/res/layout/activity_intro.xml
+++ b/example/src/main/res/layout/activity_intro.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/intro"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Kontext v4 — Character switch repro"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:paddingBottom="16dp"
+        android:text="Pick a character to open its own chat Activity (each gets a fresh Session). View an ad, press Back to destroy the Activity (session.close()), then open any character again — the OMID crash reproduces when the next ad is shown."
+        android:textSize="14sp" />
+
+    <Button
+        android:id="@+id/characterAria"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Chat with Aria" />
+
+    <Button
+        android:id="@+id/characterMilo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Chat with Milo" />
+
+    <Button
+        android:id="@+id/characterNova"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Chat with Nova" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="20dp"
+        android:background="#22000000" />
+
+    <Button
+        android:id="@+id/legacyDemo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Open legacy single-screen demo" />
+</LinearLayout>


### PR DESCRIPTION
> **Not for merge** — this is a reproduction harness for the speakmaster OMID crash. We'll close it once the root cause is confirmed and fixed in `:ads` / kontextkit-android.

## Why

speakmaster reports a deterministic crash inside the IAB OMID native `TreeWalker`:

```
java.lang.NullPointerException: Attempt to invoke virtual method
'java.lang.Object java.lang.ref.WeakReference.get()' on a null object reference
    at com.iab.omid.library.kontextso.internal.k.a
    at com.iab.omid.library.kontextso.walking.TreeWalker.l
    at com.iab.omid.library.kontextso.walking.TreeWalker$b.run
```

Per their latest testing it's **not** about switching characters. It reproduces as soon as **any** Kontext ad has been displayed, the Activity is destroyed (`session.close()` on the main thread), and a **new** Activity later shows another ad — same character or different. That points at OMID's **process-global** state (the native SDK is activated once and never deactivated; `TreeWalker` and `WebViewPool` are singletons) surviving the per-Activity `Session` and poisoning the next one.

The existing single-Activity example can't exercise this — there's no destroy-and-re-enter loop. This PR adds that lifecycle so we can reproduce and instrument it.

## What

- **`IntroActivity`** (new launcher) — pick one of three characters (Aria/Milo/Nova), plus a button to the legacy single-screen demo.
- **`CharacterChatActivity`** — a fresh `Session` per entry (own `conversationId`), seeds a greeting so an ad shows automatically, and finishes on **Back** → `session.close()` in `onDestroy`. Per-character log tag (`[Aria] …`).
- New `activity_intro.xml` / `activity_chat.xml`; manifest points the launcher at `IntroActivity` and keeps `MainActivity` reachable (non-launcher).

Matches the speakmaster shape: one Activity + one `Session` per character entry, destroyed on exit, RecyclerView + `InlineAdView`.

## Repro steps

1. Set a filling `publisherToken` (and optional `adServerUrl`) in `example/local.properties`.
2. `./gradlew :example:installDebug`
3. Launch → tap a character → wait for the ad → press **Back** → tap any character → crash hits when the next ad reaches display timing.
4. Watch logcat for `KontextExample` (our debug events) and the `com.iab.omid…TreeWalker` NPE.

## Leading hypothesis (to confirm with this harness)

An OMID `AdSession` from the first Activity is left dangling in OMID's global `TreeWalker` registry after teardown; its registered WebView is later destroyed by the pool's independent 1s `destroyDelayed`, nulling the session's view `WeakReference`. The next Activity's first ad re-arms the shared global walker, which dereferences the dead session → NPE. Concrete suspects: WebView destroyed independently of OMID removal (`WebViewPool.destroyDelayed`), and `Ad.destroy()` early-returning when `destroyed` is already set (skipping `finish()`).

Built locally against `main`'s `:ads` (`./gradlew :example:assembleDebug` ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)