### PR TITLE
chore(deps): bump KontextKit 0.0.8 (OMID off-main activation fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.4
+
+Fix an OMID crash when `createSession()` is called off the main thread.
+
+* Bump KontextKit `0.0.7` → `0.0.8`, which runs OMID's `Omid.activate()` on the main thread and disables OMID process-wide if activation ever fails. Previously, calling `KontextAds.createSession()` from a background coroutine (e.g. `Dispatchers.Default`) ran activation off-main, where OMID's internal `new Handler()` throws (no `Looper`), leaving OMID half-initialized; a later session then armed OMID's process-global `TreeWalker`, which crashed on the main thread dereferencing a never-initialized `WeakReference`. `createSession()` is now safe to call from any thread. No public API changes. See kontextso/kontextkit-android#12.
+
 ## 4.0.3
 
 Fix the traditional-View `InlineAdView` integration path (RecyclerView / XML).

--- a/ads/src/test/kotlin/so/kontext/ads/ConfigurationTest.kt
+++ b/ads/src/test/kotlin/so/kontext/ads/ConfigurationTest.kt
@@ -179,7 +179,7 @@ class ConfigurationTest {
     @Test
     fun `constants have expected values`() {
         assertEquals("sdk-kotlin", SDKInfo.NAME)
-        assertEquals("4.0.3", SDKInfo.VERSION)
+        assertEquals("4.0.4", SDKInfo.VERSION)
         assertEquals("android", SDKInfo.PLATFORM)
         assertEquals(30, Constants.MAX_MESSAGES)
     }

--- a/ads/src/test/kotlin/so/kontext/ads/PreloadTest.kt
+++ b/ads/src/test/kotlin/so/kontext/ads/PreloadTest.kt
@@ -198,7 +198,7 @@ class PreloadTest {
 
         val dto = json.decodeFromString<PreloadRequestDto>(capturedBody!!)
         assertEquals("sdk-kotlin", dto.sdk.name)
-        assertEquals("4.0.3", dto.sdk.version)
+        assertEquals("4.0.4", dto.sdk.version)
         assertEquals("android", dto.sdk.platform)
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,12 +11,12 @@
 # `./gradlew :ads:publish -PsdkVersion=4.1.0` so CI can cut patch
 # releases without bumping this file. Read at runtime as
 # `BuildConfig.SDK_VERSION` (see ads/build.gradle.kts).
-sdk-kotlin = "4.0.3"
+sdk-kotlin = "4.0.4"
 
 # ---- KontextKit ----
 # Shared device-info / privacy / UI / OMID library, published to
 # Maven Central from github.com/kontextso/kontextkit-android.
-kontext-kit = "0.0.7"
+kontext-kit = "0.0.8"
 
 # ---- Build tooling ----
 agp = "8.7.3"                       # Android Gradle Plugin (compileSdk 36 needs 8.6+; AGP 8.7+ needs Gradle 8.9)


### PR DESCRIPTION
**Draft — blocked on the KontextKit `0.0.8` release to Maven Central.** Mark ready once kontextso/kontextkit-android#12 is merged and published.

## What

Bump KontextKit `0.0.7` → `0.0.8` and SDK `4.0.3` → `4.0.4`.

KontextKit `0.0.8` (kontextso/kontextkit-android#12) fixes an OMID activation crash: calling `KontextAds.createSession()` from a background coroutine (e.g. `Dispatchers.Default`) ran OMID's `Omid.activate()` off the main thread, where its internal `new Handler()` throws (no `Looper`). OMID was left half-initialized, and a later session armed its process-global `TreeWalker`, which crashed on the main thread:

```
NullPointerException: WeakReference.get() on a null object reference
    at com.iab.omid.library.kontextso.internal.k.a → TreeWalker.l
```

With `0.0.8`, activation is posted to the main thread (non-blocking) and OMID is disabled process-wide if activation ever fails. `createSession()` is now safe from any thread. No public API changes.

## Verification

Built locally against KontextKit `0.0.8` (via Maven Local) and driven through the off-main `createSession()` repro: `valid=true` on every session across repeated character switches, no crash, no ANR, OMID genuinely active. Before the fix the same flow produced `valid=false → valid=true → crash`.

## Checklist before marking ready

- [ ] kontextso/kontextkit-android#12 merged
- [ ] KontextKit `0.0.8` published to Maven Central
- [ ] CI green (resolves `so.kontext.kit:kontext-kit-android:0.0.8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)